### PR TITLE
Deprecate glean.api.configs.consume_config and old launch scripts

### DIFF
--- a/glean/api/configs.py
+++ b/glean/api/configs.py
@@ -5,11 +5,17 @@ import os
 import re
 import yaml
 import csv
+import warnings
 import numpy as np
 from glean.api import results
 
 
 def consume_config():
+    warnings.warn(
+        "consume_config is deprecated, CLI input should be parsed in glean.cli",
+        DeprecationWarning,
+    )
+
     if len(sys.argv) < 2:
         print("Please specify a configuration (.yml) file.")
         exit()

--- a/glean/quantiles.py
+++ b/glean/quantiles.py
@@ -21,8 +21,14 @@ Supported configuration options:
 """
 
 if __name__ == "__main__":
+    import warnings
     from glean.api import quantiles
     from glean.api.configs import consume_config
+
+    warnings.warn(
+        "quantiles.py is deprecated, please use `glean quantiles`",
+        FutureWarning
+    )
 
     config, argv = consume_config()
     quantiles(argv, config)

--- a/glean/single.py
+++ b/glean/single.py
@@ -10,8 +10,14 @@ Supported configuration options:
 """
 
 if __name__ == "__main__":
+    import warnings
     from glean.api import single
     from glean.api.configs import consume_config
+
+    warnings.warn(
+        "single.py is deprecated, please use `glean single`",
+        FutureWarning
+    )
 
     config, argv = consume_config()
     single(argv, config)


### PR DESCRIPTION
close #10 
close #11 

These now give DeprecationWarning and FutureWarning.