### PR TITLE
Swap bumpversion for setuptools_scm

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       shell: bash -l {0}
       run: |
         # We really should be using an environment.yaml file for this spec
-        conda install pip numpy click pyyaml numpy scipy statsmodels netCDF4 pytest pytest-mock twine flake8 black
+        conda install pip numpy click pyyaml numpy scipy statsmodels netCDF4 pytest pytest-mock twine flake8 black setuptools_scm
     - name: Test code quality
       shell: bash -l {0}
       run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,3 @@
-[bumpversion]
-current_version = 0.1.0a0
-commit = True
-tag = True
-
-[bumpversion:file:setup.py]
-search = version="{current_version}"
-replace = version="{new_version}"
-
-[bumpversion:file:glean/__init__.py]
-search = __version__ = "{current_version}"
-replace = __version__ = "{new_version}"
-
 [bdist_wheel]
 universal = 1
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="glean",
-    version="0.1.0a0",
+    use_scm_version=True,
     description="Tools for processing results of the Climate Prospectus.",
     url="https://github.com/ClimateImpactLab/glean",
     author="James Rising",
@@ -10,6 +10,7 @@ setup(
     license="MIT",
     packages=find_packages(),
     install_requires=["click", "pyyaml", "numpy", "scipy", "statsmodels", "netCDF4"],
+    setup_requires=["setuptools_scm"],
     extras_require={
         "test": ["pytest"],
         "dev": ["pytest", "pytest-cov", "pytest-mock", "wheel", "flake8", "black", "twine"],


### PR DESCRIPTION
`bumptools` is no longer supported and `setuptools_scm` works better with our flow. We're swapping.